### PR TITLE
(feat) define title of the missed call notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ function CallKitService() {
     callConnected: execWithPlugin(function(uuid) {
       callKit.callConnected(callUUID);
     }),
-    endCall: execWithPlugin(function(notify) {
-        callKit.endCall(callUUID, notify);
+    endCall: execWithPlugin(function(notify, contentTitle) {
+        callKit.endCall(callUUID, notify, contentTitle);
     }),
     finishRing: execWithPlugin(function() {
         callKit.finishRing();
@@ -165,13 +165,13 @@ to report the system that the outgoing call is connected.
 Use
 
 ```javascript
-callKitService.endCall(uuid, notify);
+callKitService.endCall(notify, contentTitle);
 ```
 
 to let the system know, the call is ended.
 
-* *uuid: String* - Unique identifier of the call. In case of incoming call, it is provided by the `reportIncomingCall` `onSuccess` callback.
-* *notify: Boolean* - If `true`, sends a local notification to the system about the missed call.
+* *notify: boolean* - If `true`, sends a local notification to the system about the missed call.
+* *contentTitle: String* - Title of the notification (will default to `{appName} call missed`).
 
 On android the callscreen should be displayed by the app. Use
 

--- a/www/CallKit.js
+++ b/www/CallKit.js
@@ -1,88 +1,88 @@
 var exec = cordova.require('cordova/exec');
 
 var CallKit = function() {
-	console.log('CallKit instanced');
+    console.log('CallKit instanced');
 };
 
 CallKit.prototype.register = function(callChanged,audioSystem) {
-	var errorCallback = function() {};
-	var successCallback = function(obj) {
-		if (obj && obj.hasOwnProperty('callbackType')) {
-			if (obj.callbackType == "callChanged") {
-				/* this is a call changed callback! */
-				callChanged(obj);
-			} else if (obj.callbackType == "audioSystem") {
-				/* this is an audio system callback! */
-				audioSystem(obj.message);
-			}
-		} else {
-		}
-	};
+    var errorCallback = function() {};
+    var successCallback = function(obj) {
+        if (obj && obj.hasOwnProperty('callbackType')) {
+            if (obj.callbackType == "callChanged") {
+                /* this is a call changed callback! */
+                callChanged(obj);
+            } else if (obj.callbackType == "audioSystem") {
+                /* this is an audio system callback! */
+                audioSystem(obj.message);
+            }
+        } else {
+        }
+    };
 
-	exec(successCallback, errorCallback, 'CallKit', 'register' );
+    exec(successCallback, errorCallback, 'CallKit', 'register' );
 };
 
 CallKit.prototype.reportIncomingCall = function(name,params,onSuccess) {
-	var supportsVideo = true;
-	var supportsGroup = false;
-	var supportsUngroup = false;
-	var supportsDTMF = false;
-	var supportsHold = false;
+    var supportsVideo = true;
+    var supportsGroup = false;
+    var supportsUngroup = false;
+    var supportsDTMF = false;
+    var supportsHold = false;
 
-	if (typeof params === "boolean") {
-		supportsVideo = params;
-	} else if (typeof params === "object") {
-		supportsVideo = (params.video === true);
-		supportsGroup = (params.group === true);
-		supportsUngroup = (params.ungroup === true);
-		supportsDTMF = (params.dtmf === true);
-		supportsHold = (params.hold === true);
-	}
+    if (typeof params === "boolean") {
+        supportsVideo = params;
+    } else if (typeof params === "object") {
+        supportsVideo = (params.video === true);
+        supportsGroup = (params.group === true);
+        supportsUngroup = (params.ungroup === true);
+        supportsDTMF = (params.dtmf === true);
+        supportsHold = (params.hold === true);
+    }
 
-	var errorCallback = function() {};
-	var successCallback = function(obj) {
-		onSuccess(obj);
-	};
+    var errorCallback = function() {};
+    var successCallback = function(obj) {
+        onSuccess(obj);
+    };
 
-	exec(successCallback, errorCallback, 'CallKit', 'reportIncomingCall', [name, supportsVideo, supportsGroup, supportsUngroup, supportsDTMF, supportsHold] );
+    exec(successCallback, errorCallback, 'CallKit', 'reportIncomingCall', [name, supportsVideo, supportsGroup, supportsUngroup, supportsDTMF, supportsHold] );
 };
 
 CallKit.prototype.askNotificationPermission = function() {
-	// TODO: allow user to pass a succes/error callback to know the user's answer
-	var cb = function() {};
-	exec(cb, cb, 'CallKit', 'askNotificationPermission', []);
+    // TODO: allow user to pass a succes/error callback to know the user's answer
+    var cb = function() {};
+    exec(cb, cb, 'CallKit', 'askNotificationPermission', []);
 };
 
 CallKit.prototype.startCall = function(name,isVideo,onSuccess) {
-	var errorCallback = function() {};
-	var successCallback = function(obj) {
-		onSuccess(obj);
-	};
+    var errorCallback = function() {};
+    var successCallback = function(obj) {
+        onSuccess(obj);
+    };
 
-	exec(successCallback, errorCallback, 'CallKit', 'startCall', [name, isVideo] );
+    exec(successCallback, errorCallback, 'CallKit', 'startCall', [name, isVideo] );
 };
 
 CallKit.prototype.callConnected = function(uuid) {
-	var errorCallback = function() {};
-	var successCallback = function() {};
+    var errorCallback = function() {};
+    var successCallback = function() {};
 
-	exec(successCallback, errorCallback, 'CallKit', 'callConnected', [uuid] );
+    exec(successCallback, errorCallback, 'CallKit', 'callConnected', [uuid] );
 };
 
-CallKit.prototype.endCall = function(uuid,notify) {
-	var errorCallback = function() {};
-	var successCallback = function() {};
+CallKit.prototype.endCall = function(uuid, notify, contentTitle) {
+    var errorCallback = function() {};
+    var successCallback = function() {};
 
-	exec(successCallback, errorCallback, 'CallKit', 'endCall', [uuid, notify] );
+    exec(successCallback, errorCallback, 'CallKit', 'endCall', [uuid, notify, contentTitle] );
 };
 
 CallKit.prototype.finishRing = function(uuid) {
-	var errorCallback = function() {};
-	var successCallback = function() {};
+    var errorCallback = function() {};
+    var successCallback = function() {};
 
-	exec(successCallback, errorCallback, 'CallKit', 'finishRing', [uuid] );
+    exec(successCallback, errorCallback, 'CallKit', 'finishRing', [uuid] );
 };
 
 if (typeof module != 'undefined' && module.exports) {
-	module.exports = CallKit;
+    module.exports = CallKit;
 }


### PR DESCRIPTION
Hi Taracque,

I just noticed that the notification created by the plugin (on Android) had its title hardcoded in the Java sources (`{appName} call missed`). I thought it would be a good idea to allow users defining it themselves as a parameter of `endCall` (but it will still default to the current value).

Thanks for your work, again.

Regards 